### PR TITLE
hypothetical roster generator

### DIFF
--- a/server.rb
+++ b/server.rb
@@ -140,6 +140,14 @@ post '/match', :provides => :json do
   halt 200, {:params => params, :result => result}.to_json
 end
 
+get %{^/roster---([a-z0-9-]+)\.json$} do |slug|
+  headers 'Access-Control-Allow-Origin' => '*'
+  {
+    title:"Roster - #{slug}",
+    story:[ {type:roster, text:sites('slugs','and',slug).join("\n")} ]}
+  }
+end
+
 get '/favicon.png' do
   headers 'Access-Control-Allow-Origin' => '*'
   send_file 'favicon.png'


### PR DESCRIPTION
NOT FOR MERGE

Here we show how a server might generate a wide variety of rosters based on parameters it finds in a slug. This requires some ingenuity as the slug is of limited character set but not limited in length. 

We will create a large number of rosters where each appears to be on its own page but will instead be generated on demand from search results. We imagine creating a page with a title `Roster chorus-of-voices` which is to contain one item, a roster of sites that have the page, Chorus of Voices.

The same technique could be used to query any other database of sites for particular subsets based on parameters encoded into the title/slug.