### PR TITLE
add linux demo instructions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1.111.0
+        uses: ruby/setup-ruby@v1.233.0
         with:
-          ruby-version: 3.1.2
+          ruby-version: 3.2.8
       - name: Setup Graphviz
         run: |
           sudo apt-get update

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ pages/recent-activity
 pages/visible-federation
 trouble
 sqlite/geonames-*
+demo/wiki/config.json

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "sinatra", "~> 4.1"
+gem "rackup", "~> 2.2"
+gem "puma", "~> 6.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,40 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    base64 (0.2.0)
+    logger (1.7.0)
+    mustermann (3.0.3)
+      ruby2_keywords (~> 0.0.1)
+    nio4r (2.7.4)
+    puma (6.6.0)
+      nio4r (~> 2.0)
+    rack (3.1.13)
+    rack-protection (4.1.1)
+      base64 (>= 0.1.0)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.1.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
+    rackup (2.2.1)
+      rack (>= 3)
+    ruby2_keywords (0.0.5)
+    sinatra (4.1.1)
+      logger (>= 1.6.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.1.1)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    tilt (2.6.0)
+
+PLATFORMS
+  x86_64-linux-gnu
+
+DEPENDENCIES
+  puma (~> 6.6)
+  rackup (~> 2.2)
+  sinatra (= 4.1.1)
+
+BUNDLED WITH
+   2.4.20

--- a/demo/linux.md
+++ b/demo/linux.md
@@ -1,0 +1,147 @@
+#  Run for yourself
+
+You want to become a considerate maintainer of a federation scrape service.
+
+These are steps that help you to get set up on Ubuntu Linux.
+
+## Prerequisites
+
+Install these dependencies, if not yet available to your system.
+
+- cron
+- sh
+- ruby
+
+Some optional dependencies exist for extended usage.
+
+- caddy
+- deno
+
+```sh
+sudo apt install -y ruby bundler
+```
+
+The repository comes with a `Gemfile` to describe Ruby dependencies.
+
+Make sure you have a writable `GEM_HOME` directory, e.g. with adding to `.bashrc`:
+
+```sh
+export GEM_HOME="$(ruby -e 'puts Gem.user_dir')"
+export PATH="$GEM_HOME/bin:$PATH"
+```
+
+Install the Ruby dependencies with:
+
+```sh
+bundle install
+```
+
+## Preparation
+
+The code assumes in many place from where it is made available.
+Adapt this location to your preference.
+
+```sh
+xargs -L1 sed 's/search.fed.wiki.org/search.federatedwiki.org/g' -i <<<"online.pl
+  pages/welcome-visitors
+  public/title-search.html
+  public/title.html
+  server.rb"
+```
+
+We also need a little upgrade, if we want to run from Ruby 3.
+
+```sh
+xargs -L1 sed 's/Dir.exists/Dir.exist/' -i <<<"slug-web.rb
+site-web.rb"
+```
+
+You will need at least one seed site to start from. Additionally we prepare the
+retired store.
+
+Then prefill the index by an initial run of the cron script.
+
+```sh
+mkdir -p sites/{fed.wiki.org,fed.wiki,federated.wiki,verbund.wiki,commoning.wiki}/pages retired
+LANG="en_US.UTF-8" sh cron.sh
+```
+
+Initially, this will take a lot of time. Wait for the process to complete.
+
+Observe its doings for a current time window with e.g.:
+
+```sh
+tail -f logs/Tue-1800
+```
+
+An exemplary initial run took four and a half hours.
+
+## Running
+
+Running the federation wiki scraper requires to handle a few components.
+
+See the [Subsystem Diagrams](http://scrape.fed.wiki/subsystem-diagrams.html)
+and the [Resource Checklist](http://scrape.fed.wiki/resource-checklist.html)
+for details.
+
+More background can be explored from the [Search Overview](http://ward.asia.wiki.org/view/ruby-sitemap-scrape/view/how-scrape-works/view/search-index-downloads/view/sitemap-failures/view/sitemap-scrape-improvements/view/link-symmetry/view/newly-found-sites/view/full-scrape/scrape.ward.bay.wiki.org/how-search-works/scrape.ward.bay.wiki.org/search-overview) lineup.
+
+### Activating scheduled cron execution
+
+Add the `cron.sh` script to your user crontab.
+
+```sh
+( ( crontab -l ; echo "0 */6 * * * (cd $HOME/src/github.com/WardCunningham/search; LANG="en_US.UTF-8" sh cron.sh)" ) | crontab - ) >& /dev/null
+```
+
+### Starting the server
+
+A systemd service unit is created with
+
+```sh
+systemctl edit --user --force --full wiki-search-server
+```
+
+Fill it with:
+
+```ini
+[Unit]
+Description=Wiki search service
+Requires=default.target
+
+[Service]
+Type=simple
+Environment=APP_ENV=production
+Environment=GEM_HOME=/home/ubuntu/.local/share/gem/ruby/3.2.0
+WorkingDirectory=/home/ubuntu/src/github.com/WardCunningham/search
+ExecStart=/usr/bin/ruby /home/ubuntu/src/github.com/WardCunningham/search/server.rb -p 3030
+Restart=always
+TimeoutSec=10
+
+[Install]
+WantedBy=default.target
+```
+
+Reload your daemon to use it.
+
+```sh
+systemctl daemon-reload --user
+systemctl enable --user --now wiki-search-server
+```
+
+The search is now available at <http://search.federatedwiki.org:3030>.
+
+Persist the user service with enabling linger mode:
+
+```sh
+sudo loginctl enable-linger ubuntu
+```
+
+For serving the query interface using the default HTTP port, use:
+
+```
+sudo printf "http://query.search.federatedwiki.org {\n  reverse_proxy localhost:3030\n}\n" > /etc/caddy/Caddyfile
+sudo systemctl restart caddy
+```
+
+The query interface for the search is then also available at <http://query.search.federatedwiki.org>.

--- a/demo/linux.md
+++ b/demo/linux.md
@@ -99,7 +99,7 @@ Add the `cron.sh` script to your user crontab.
 A systemd service unit is created with
 
 ```sh
-systemctl edit --user --force --full wiki-search-server
+systemctl edit --user --force --full wiki-search
 ```
 
 Fill it with:
@@ -126,7 +126,7 @@ Reload your daemon to use it.
 
 ```sh
 systemctl daemon-reload --user
-systemctl enable --user --now wiki-search-server
+systemctl enable --user --now wiki-search
 ```
 
 The search is now available at <http://search.federatedwiki.org:3030>.

--- a/demo/linux.md
+++ b/demo/linux.md
@@ -140,7 +140,15 @@ sudo loginctl enable-linger ubuntu
 For serving the query interface using the default HTTP port, use:
 
 ```
-sudo printf "http://query.search.federatedwiki.org {\n  reverse_proxy localhost:3030\n}\n" > /etc/caddy/Caddyfile
+sudo cat <<CADDYFILE > /etc/caddy/Caddyfile
+> {
+  email acme@search.federatedwiki.org
+}
+
+http://query.search.federatedwiki.org, https://query.search.federatedwiki.org {
+  reverse_proxy localhost:3030
+}
+CADDYFILE
 sudo systemctl restart caddy
 ```
 

--- a/demo/wiki/config.json.example
+++ b/demo/wiki/config.json.example
@@ -1,0 +1,6 @@
+{
+  "url": "http://search.federatedwiki.org",
+  "security_type": "friends",
+  "cookieSecret": "<openssl rand -base64 48>",
+  "sessionDuration": 30
+}

--- a/demo/wiki/config.json.example
+++ b/demo/wiki/config.json.example
@@ -2,5 +2,5 @@
   "url": "http://search.federatedwiki.org",
   "security_type": "friends",
   "cookieSecret": "<openssl rand -base64 48>",
-  "sessionDuration": 30
+  "session_duration": 30
 }

--- a/demo/wiki/pages/federation-search
+++ b/demo/wiki/pages/federation-search
@@ -4,7 +4,7 @@
     {
       "type": "paragraph",
       "id": "35ef8c871dc5b524",
-      "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. [http://search.fed.wiki.org:3030 search]"
+      "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. [http://query.search.federatedwiki.org search]"
     },
     {
       "type": "paragraph",
@@ -71,7 +71,7 @@
       "item": {
         "type": "paragraph",
         "id": "35ef8c871dc5b524",
-        "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. Maybe it will stay that way. [http://search.fed.wiki.org:3030 search]"
+        "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. Maybe it will stay that way. [http://query.search.federatedwiki.org search]"
       },
       "date": 1437341347024
     },
@@ -81,7 +81,7 @@
       "item": {
         "type": "paragraph",
         "id": "35ef8c871dc5b524",
-        "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. [http://search.fed.wiki.org:3030 search]"
+        "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. [http://query.search.federatedwiki.org search]"
       },
       "date": 1437341360054
     },

--- a/demo/wiki/pages/federation-search
+++ b/demo/wiki/pages/federation-search
@@ -1,0 +1,1040 @@
+{
+  "title": "Federation Search",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "35ef8c871dc5b524",
+      "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. [http://search.fed.wiki.org:3030 search]"
+    },
+    {
+      "type": "paragraph",
+      "id": "2f9e59bed4eefd57",
+      "text": "[[Search Help]] using the web interface."
+    },
+    {
+      "type": "paragraph",
+      "id": "6e6083e8ed5622d2",
+      "text": "[[Search Findings]] reported as a Roster of active sites."
+    },
+    {
+      "type": "paragraph",
+      "id": "924eda2931f04265",
+      "text": "This is an experimental service that we expect to change dramatically as we bring more search technology to bear and have more sites to search."
+    },
+    {
+      "type": "paragraph",
+      "id": "d249b014a83af1ac",
+      "text": "First we will make this interesting, then we'll make it fast, then we will integrate it with wiki itself making the whole federation close at hand."
+    },
+    {
+      "type": "paragraph",
+      "id": "115edeb95dbec45f",
+      "text": "Future versions will do stemmed and multi-word queries."
+    },
+    {
+      "type": "paragraph",
+      "id": "3de693abcc3e0f3a",
+      "text": "Future versions will quote site and page counts."
+    },
+    {
+      "type": "paragraph",
+      "id": "ad88fd7655f84a1e",
+      "text": "Future versions will plot page and site networks."
+    },
+    {
+      "type": "paragraph",
+      "id": "4330b62208e84008",
+      "text": "Future versions will be included in each wiki server."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Federation Search",
+        "story": []
+      },
+      "date": 1437341216997
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "35ef8c871dc5b524"
+      },
+      "id": "35ef8c871dc5b524",
+      "type": "add",
+      "date": 1437341231013
+    },
+    {
+      "type": "edit",
+      "id": "35ef8c871dc5b524",
+      "item": {
+        "type": "paragraph",
+        "id": "35ef8c871dc5b524",
+        "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. Maybe it will stay that way. [http://search.fed.wiki.org:3030 search]"
+      },
+      "date": 1437341347024
+    },
+    {
+      "type": "edit",
+      "id": "35ef8c871dc5b524",
+      "item": {
+        "type": "paragraph",
+        "id": "35ef8c871dc5b524",
+        "text": "We're experimenting with full text search of the federation. For the moment this is both easier to code and easier to host than searching the web. [http://search.fed.wiki.org:3030 search]"
+      },
+      "date": 1437341360054
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "7af72b0cdcb1c394"
+      },
+      "id": "7af72b0cdcb1c394",
+      "type": "add",
+      "after": "35ef8c871dc5b524",
+      "date": 1437342358271
+    },
+    {
+      "type": "edit",
+      "id": "7af72b0cdcb1c394",
+      "item": {
+        "type": "paragraph",
+        "id": "7af72b0cdcb1c394",
+        "text": "We search the text property of all story items for exact matches of alphanumeric strings."
+      },
+      "date": 1437342520954
+    },
+    {
+      "type": "add",
+      "id": "115edeb95dbec45f",
+      "item": {
+        "type": "paragraph",
+        "id": "115edeb95dbec45f",
+        "text": "Future versions will do word stemming and multi-word queries."
+      },
+      "after": "7af72b0cdcb1c394",
+      "date": 1437342553577
+    },
+    {
+      "type": "add",
+      "id": "52f7aebca568a4de",
+      "item": {
+        "type": "paragraph",
+        "id": "52f7aebca568a4de",
+        "text": "Future versions will support \"who links here\"."
+      },
+      "after": "115edeb95dbec45f",
+      "date": 1437342611230
+    },
+    {
+      "type": "edit",
+      "id": "115edeb95dbec45f",
+      "item": {
+        "type": "paragraph",
+        "id": "115edeb95dbec45f",
+        "text": "Future versions will do stemmed and multi-word queries."
+      },
+      "date": 1437342650829
+    },
+    {
+      "type": "add",
+      "id": "3de693abcc3e0f3a",
+      "item": {
+        "type": "paragraph",
+        "id": "3de693abcc3e0f3a",
+        "text": "Future versions will quote the size of the federation."
+      },
+      "after": "52f7aebca568a4de",
+      "date": 1437342688066
+    },
+    {
+      "type": "edit",
+      "id": "3de693abcc3e0f3a",
+      "item": {
+        "type": "paragraph",
+        "id": "3de693abcc3e0f3a",
+        "text": "Future versions will quote site and page counts."
+      },
+      "date": 1437342717922
+    },
+    {
+      "type": "add",
+      "id": "6ee19517037c5fab",
+      "item": {
+        "type": "paragraph",
+        "id": "6ee19517037c5fab",
+        "text": "Future versions will report pages as well as sites."
+      },
+      "after": "7af72b0cdcb1c394",
+      "date": 1437342776727
+    },
+    {
+      "type": "edit",
+      "id": "7af72b0cdcb1c394",
+      "item": {
+        "type": "paragraph",
+        "id": "7af72b0cdcb1c394",
+        "text": "We search the text property of all story items for exact matches of alphanumeric strings and report sites where they are found."
+      },
+      "date": 1437342838259
+    },
+    {
+      "type": "add",
+      "id": "ad88fd7655f84a1e",
+      "item": {
+        "type": "paragraph",
+        "id": "ad88fd7655f84a1e",
+        "text": "Future versions will plot page and site networks."
+      },
+      "after": "3de693abcc3e0f3a",
+      "date": 1437342881961
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "40dfb6607974b68b"
+      },
+      "id": "40dfb6607974b68b",
+      "type": "add",
+      "after": "ad88fd7655f84a1e",
+      "date": 1437489869643
+    },
+    {
+      "type": "edit",
+      "id": "40dfb6607974b68b",
+      "item": {
+        "type": "paragraph",
+        "id": "40dfb6607974b68b",
+        "text": "See [[Recent Activity]]"
+      },
+      "date": 1437489894825
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "reference",
+        "id": "6135de790833050f",
+        "site": "search.fed.wiki.org:3030",
+        "slug": "recent-activity",
+        "title": "Recent Activity",
+        "text": "Here we report sites we find with recently edited pages."
+      },
+      "after": "ad88fd7655f84a1e",
+      "id": "6135de790833050f",
+      "date": 1437839305523
+    },
+    {
+      "type": "remove",
+      "id": "40dfb6607974b68b",
+      "date": 1437839309202
+    },
+    {
+      "type": "edit",
+      "id": "6135de790833050f",
+      "item": {
+        "type": "reference",
+        "id": "6135de790833050f",
+        "site": "search.fed.wiki.org:3030",
+        "slug": "recent-activity",
+        "title": "Recent Activity",
+        "text": "Here we report sites we find with recently edited pages. Note: the server on this port serves only this one page, not everything expected of a wiki."
+      },
+      "date": 1437840388728
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "74e3ae29140d3a01"
+      },
+      "id": "74e3ae29140d3a01",
+      "type": "add",
+      "after": "6135de790833050f",
+      "date": 1437950799601
+    },
+    {
+      "type": "remove",
+      "id": "74e3ae29140d3a01",
+      "date": 1437950816509
+    },
+    {
+      "type": "edit",
+      "id": "7af72b0cdcb1c394",
+      "item": {
+        "type": "paragraph",
+        "id": "7af72b0cdcb1c394",
+        "text": "We search the text property of all story items for exact matches of alphanumeric strings and"
+      },
+      "date": 1437951130796
+    },
+    {
+      "type": "add",
+      "id": "84380411e6889f51",
+      "item": {
+        "type": "paragraph",
+        "id": "84380411e6889f51",
+        "text": " report sites where they are found."
+      },
+      "after": "7af72b0cdcb1c394",
+      "date": 1437951133292
+    },
+    {
+      "type": "edit",
+      "id": "7af72b0cdcb1c394",
+      "item": {
+        "type": "paragraph",
+        "id": "7af72b0cdcb1c394",
+        "text": "We search various properties of pages for exact matches of search terms."
+      },
+      "date": 1437951221970
+    },
+    {
+      "type": "edit",
+      "id": "7af72b0cdcb1c394",
+      "item": {
+        "type": "paragraph",
+        "id": "7af72b0cdcb1c394",
+        "text": "We search various properties of pages for exact matches of search terms. Select what you would like to find."
+      },
+      "date": 1437951247122
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "find:\n      <td><input type=\"radio\" name=\"find\" value=\"words\" checked>words</input>\n      <td><input type=\"radio\" name=\"find\" value=\"links\">links</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>"
+      },
+      "after": "7af72b0cdcb1c394",
+      "id": "8e6df6b2da1633c4",
+      "date": 1437951255878
+    },
+    {
+      "type": "edit",
+      "id": "84380411e6889f51",
+      "item": {
+        "type": "paragraph",
+        "id": "84380411e6889f51",
+        "text": "We report either the sites or the pages within sites where the terms are found."
+      },
+      "date": 1437951487955
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "within:\n      <td><input type=\"radio\" name=\"within\" value=\"sites\" checked>sites</input>\n      <td><input type=\"radio\" name=\"within\" value=\"pages\">pages</input>"
+      },
+      "after": "84380411e6889f51",
+      "id": "1e14f79ab65c3d57",
+      "date": 1437951529151
+    },
+    {
+      "type": "add",
+      "id": "556589aee9ec227b",
+      "item": {
+        "type": "paragraph",
+        "id": "556589aee9ec227b",
+        "text": "Enter one or more terms. Press enter to search."
+      },
+      "after": "6ee19517037c5fab",
+      "date": 1437951645416
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "6ee19517037c5fab",
+        "115edeb95dbec45f",
+        "52f7aebca568a4de",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f"
+      ],
+      "id": "556589aee9ec227b",
+      "date": 1437951648968
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "68d6dcb91bc176fe",
+        "text": " <input class=query type=text size=40></input>",
+        "alias": "1e14f79ab65c3d57"
+      },
+      "after": "556589aee9ec227b",
+      "id": "68d6dcb91bc176fe",
+      "date": 1437951665793
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "742c8c14e6d4d985"
+      },
+      "id": "742c8c14e6d4d985",
+      "type": "add",
+      "after": "6135de790833050f",
+      "date": 1437951691318
+    },
+    {
+      "type": "edit",
+      "id": "742c8c14e6d4d985",
+      "item": {
+        "type": "pagefold",
+        "id": "742c8c14e6d4d985",
+        "text": "instructions"
+      },
+      "date": 1437951698363
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "6ee19517037c5fab",
+        "115edeb95dbec45f",
+        "52f7aebca568a4de",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f"
+      ],
+      "id": "742c8c14e6d4d985",
+      "date": 1437951704880
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "02b79ce31feddc1b"
+      },
+      "id": "02b79ce31feddc1b",
+      "type": "add",
+      "after": "6135de790833050f",
+      "date": 1437951711468
+    },
+    {
+      "type": "edit",
+      "id": "02b79ce31feddc1b",
+      "item": {
+        "type": "pagefold",
+        "id": "02b79ce31feddc1b",
+        "text": "."
+      },
+      "date": 1437951714898
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "6ee19517037c5fab",
+        "115edeb95dbec45f",
+        "52f7aebca568a4de",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f"
+      ],
+      "id": "02b79ce31feddc1b",
+      "date": 1437951719986
+    },
+    {
+      "type": "fork",
+      "date": 1437951779510
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "19ca0d2881e0c693"
+      },
+      "id": "19ca0d2881e0c693",
+      "type": "add",
+      "after": "6135de790833050f",
+      "date": 1437951786443
+    },
+    {
+      "type": "edit",
+      "id": "19ca0d2881e0c693",
+      "item": {
+        "type": "pagefold",
+        "id": "19ca0d2881e0c693",
+        "text": "done"
+      },
+      "date": 1437951791038
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "6ee19517037c5fab",
+        "115edeb95dbec45f",
+        "52f7aebca568a4de",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "19ca0d2881e0c693",
+        "6135de790833050f"
+      ],
+      "id": "19ca0d2881e0c693",
+      "date": 1437951797080
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "115edeb95dbec45f",
+        "52f7aebca568a4de",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "19ca0d2881e0c693",
+        "6ee19517037c5fab",
+        "6135de790833050f"
+      ],
+      "id": "6ee19517037c5fab",
+      "date": 1437951802103
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "19ca0d2881e0c693",
+        "6ee19517037c5fab",
+        "52f7aebca568a4de",
+        "6135de790833050f"
+      ],
+      "id": "52f7aebca568a4de",
+      "date": 1437951806819
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "24f518e1eeb55e10"
+      },
+      "id": "24f518e1eeb55e10",
+      "type": "add",
+      "after": "6135de790833050f",
+      "date": 1437951817650
+    },
+    {
+      "type": "edit",
+      "id": "24f518e1eeb55e10",
+      "item": {
+        "type": "pagefold",
+        "id": "24f518e1eeb55e10",
+        "text": "."
+      },
+      "date": 1437951821229
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "19ca0d2881e0c693",
+        "6ee19517037c5fab",
+        "52f7aebca568a4de",
+        "24f518e1eeb55e10",
+        "6135de790833050f"
+      ],
+      "id": "24f518e1eeb55e10",
+      "date": 1437951829386
+    },
+    {
+      "type": "remove",
+      "id": "52f7aebca568a4de",
+      "date": 1437954656247
+    },
+    {
+      "type": "remove",
+      "id": "6ee19517037c5fab",
+      "date": 1437954660372
+    },
+    {
+      "type": "remove",
+      "id": "19ca0d2881e0c693",
+      "date": 1437954665759
+    },
+    {
+      "type": "remove",
+      "id": "24f518e1eeb55e10",
+      "date": 1437954671433
+    },
+    {
+      "type": "add",
+      "id": "924eda2931f04265",
+      "item": {
+        "type": "paragraph",
+        "id": "924eda2931f04265",
+        "text": "This is an experimental service that we expect to change dramatically as we bring more search technology to bear and have more sites to search."
+      },
+      "after": "ad88fd7655f84a1e",
+      "date": 1437954861385
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "924eda2931f04265",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f"
+      ],
+      "id": "924eda2931f04265",
+      "date": 1437954864961
+    },
+    {
+      "type": "edit",
+      "id": "6135de790833050f",
+      "item": {
+        "type": "reference",
+        "id": "6135de790833050f",
+        "site": "search.fed.wiki.org:3030",
+        "slug": "recent-activity",
+        "title": "Recent Activity",
+        "text": "Here we report sites we find with recently edited pages. You can incorporate this roster in pages you visit often using the Roster plugin with the ROSTER markup. "
+      },
+      "date": 1437962132421
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "code",
+        "id": "582903af82dd2a96",
+        "text": "ROSTER search.fed.wiki.org/recent-activity"
+      },
+      "after": "6135de790833050f",
+      "id": "582903af82dd2a96",
+      "date": 1437962140763
+    },
+    {
+      "type": "edit",
+      "id": "582903af82dd2a96",
+      "item": {
+        "type": "code",
+        "id": "582903af82dd2a96",
+        "text": "ROSTER search.fed.wiki.org:3030/recent-activity"
+      },
+      "date": 1437962148027
+    },
+    {
+      "type": "add",
+      "id": "d249b014a83af1ac",
+      "item": {
+        "type": "paragraph",
+        "id": "d249b014a83af1ac",
+        "text": "First we will make this interesting, then we'll make it fast, then we will integrate it with wiki itself making the whole federation close at hand."
+      },
+      "after": "35ef8c871dc5b524",
+      "date": 1438537340080
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "924eda2931f04265",
+        "d249b014a83af1ac",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f",
+        "582903af82dd2a96"
+      ],
+      "id": "d249b014a83af1ac",
+      "date": 1438537360582
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "7ff25c9d84b3becf"
+      },
+      "id": "7ff25c9d84b3becf",
+      "type": "add",
+      "after": "582903af82dd2a96",
+      "date": 1438537462515
+    },
+    {
+      "type": "remove",
+      "id": "7ff25c9d84b3becf",
+      "date": 1438537487363
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "find:\n      <td><input type=\"radio\" name=\"find\" value=\"words\" checked>words</input>\n      <td><input type=\"radio\" name=\"find\" value=\"links\">links</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>"
+      },
+      "date": 1439355114656
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "find:\n      <td><input type=\"radio\" checked>words</input>\n      <td><input type=\"radio\" name=\"find\" value=\"links\">links</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>\n      <td><input type=\"radio\" name=\"find\" value=\"sites\">sites</input>"
+      },
+      "date": 1439355169520
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "find:\n      <td><input type=\"radio\" checked>words</input>\n      <td><input type=\"radio\">links</input>\n      <td><input type=\"radio\">sites</input>\n      <td><input type=\"radio\">items</input>\n      <td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439355221715
+    },
+    {
+      "type": "edit",
+      "id": "1e14f79ab65c3d57",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "within:\n      <td><input type=\"radio\" checked>sites</input>\n      <td><input type=\"radio\">pages</input>"
+      },
+      "date": 1439355243244
+    },
+    {
+      "type": "edit",
+      "id": "1e14f79ab65c3d57",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "within:\n<td><input type=\"radio\" checked>sites</input>\n<td><input type=\"radio\">pages</input>"
+      },
+      "date": 1439355254572
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "find:\n<td><input type=\"radio\" checked>words</input>\n<td><input type=\"radio\">links</input>\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439355280578
+    },
+    {
+      "type": "add",
+      "id": "d4652dad49a7a8f7",
+      "item": {
+        "type": "paragraph",
+        "id": "d4652dad49a7a8f7",
+        "text": "We select based on matches of any or all these terms."
+      },
+      "after": "7af72b0cdcb1c394",
+      "date": 1439355421875
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "d4652dad49a7a8f7",
+        "84380411e6889f51",
+        "1e14f79ab65c3d57",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "924eda2931f04265",
+        "d249b014a83af1ac",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f",
+        "582903af82dd2a96"
+      ],
+      "id": "d4652dad49a7a8f7",
+      "date": 1439355426724
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "a2bb7187d44efb09"
+      },
+      "id": "a2bb7187d44efb09",
+      "type": "add",
+      "after": "582903af82dd2a96",
+      "date": 1439355434216
+    },
+    {
+      "type": "remove",
+      "id": "a2bb7187d44efb09",
+      "date": 1439355445381
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "051452b060a3721d",
+        "text": "within:\n<td><input type=\"radio\" checked>sites</input>\n<td><input type=\"radio\">pages</input>",
+        "alias": "1e14f79ab65c3d57"
+      },
+      "after": "d4652dad49a7a8f7",
+      "id": "051452b060a3721d",
+      "date": 1439355501285
+    },
+    {
+      "type": "edit",
+      "id": "1e14f79ab65c3d57",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "match:\n<td><input type=\"radio\" checked>all</input>\n<td><input type=\"radio\">any</input>"
+      },
+      "date": 1439355518735
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "d4652dad49a7a8f7",
+        "1e14f79ab65c3d57",
+        "051452b060a3721d",
+        "84380411e6889f51",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "924eda2931f04265",
+        "d249b014a83af1ac",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f",
+        "582903af82dd2a96"
+      ],
+      "id": "1e14f79ab65c3d57",
+      "date": 1439355537575
+    },
+    {
+      "type": "move",
+      "order": [
+        "35ef8c871dc5b524",
+        "742c8c14e6d4d985",
+        "7af72b0cdcb1c394",
+        "8e6df6b2da1633c4",
+        "d4652dad49a7a8f7",
+        "1e14f79ab65c3d57",
+        "84380411e6889f51",
+        "051452b060a3721d",
+        "556589aee9ec227b",
+        "68d6dcb91bc176fe",
+        "02b79ce31feddc1b",
+        "924eda2931f04265",
+        "d249b014a83af1ac",
+        "115edeb95dbec45f",
+        "3de693abcc3e0f3a",
+        "ad88fd7655f84a1e",
+        "6135de790833050f",
+        "582903af82dd2a96"
+      ],
+      "id": "051452b060a3721d",
+      "date": 1439355541066
+    },
+    {
+      "type": "remove",
+      "id": "556589aee9ec227b",
+      "date": 1439355610454
+    },
+    {
+      "type": "remove",
+      "id": "68d6dcb91bc176fe",
+      "date": 1439355614998
+    },
+    {
+      "type": "fork",
+      "date": 1439355897018
+    },
+    {
+      "type": "add",
+      "id": "2f9e59bed4eefd57",
+      "item": {
+        "type": "paragraph",
+        "id": "2f9e59bed4eefd57",
+        "text": "[[Search Help]]"
+      },
+      "after": "35ef8c871dc5b524",
+      "date": 1439356690501
+    },
+    {
+      "type": "edit",
+      "id": "2f9e59bed4eefd57",
+      "item": {
+        "type": "paragraph",
+        "id": "2f9e59bed4eefd57",
+        "text": "[[Search Help]] using the web interface."
+      },
+      "date": 1439356778339
+    },
+    {
+      "type": "remove",
+      "id": "742c8c14e6d4d985",
+      "date": 1439357132726
+    },
+    {
+      "type": "remove",
+      "id": "7af72b0cdcb1c394",
+      "date": 1439357138395
+    },
+    {
+      "type": "remove",
+      "id": "8e6df6b2da1633c4",
+      "date": 1439357142895
+    },
+    {
+      "type": "remove",
+      "id": "d4652dad49a7a8f7",
+      "date": 1439357146959
+    },
+    {
+      "type": "remove",
+      "id": "1e14f79ab65c3d57",
+      "date": 1439357150990
+    },
+    {
+      "type": "remove",
+      "id": "84380411e6889f51",
+      "date": 1439357155222
+    },
+    {
+      "type": "remove",
+      "id": "051452b060a3721d",
+      "date": 1439357159593
+    },
+    {
+      "type": "remove",
+      "id": "02b79ce31feddc1b",
+      "date": 1439357170240
+    },
+    {
+      "type": "add",
+      "id": "6e6083e8ed5622d2",
+      "item": {
+        "type": "paragraph",
+        "id": "6e6083e8ed5622d2",
+        "text": "[[Search Discoveries]] reported as a Roster of active sites."
+      },
+      "after": "2f9e59bed4eefd57",
+      "date": 1439358724202
+    },
+    {
+      "type": "edit",
+      "id": "6e6083e8ed5622d2",
+      "item": {
+        "type": "paragraph",
+        "id": "6e6083e8ed5622d2",
+        "text": "[[Search News]] reported as a Roster of active sites."
+      },
+      "date": 1439358742766
+    },
+    {
+      "type": "edit",
+      "id": "6e6083e8ed5622d2",
+      "item": {
+        "type": "paragraph",
+        "id": "6e6083e8ed5622d2",
+        "text": "[[Search Findings]] reported as a Roster of active sites."
+      },
+      "date": 1439358757873
+    },
+    {
+      "type": "remove",
+      "id": "6135de790833050f",
+      "date": 1439359241081
+    },
+    {
+      "type": "remove",
+      "id": "582903af82dd2a96",
+      "date": 1439359244857
+    },
+    {
+      "type": "add",
+      "id": "4330b62208e84008",
+      "item": {
+        "type": "paragraph",
+        "id": "4330b62208e84008",
+        "text": "Future versions will be included in each wiki server."
+      },
+      "after": "ad88fd7655f84a1e",
+      "date": 1439359457755
+    }
+  ]
+}

--- a/demo/wiki/pages/search-help
+++ b/demo/wiki/pages/search-help
@@ -4,7 +4,7 @@
     {
       "type": "paragraph",
       "id": "055352e0caf16e24",
-      "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select. [http://search.fed.wiki.org:3030/ site]"
+      "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select. [http://query.search.federatedwiki.org/ site]"
     },
     {
       "type": "pagefold",
@@ -423,7 +423,7 @@
       "item": {
         "type": "paragraph",
         "id": "055352e0caf16e24",
-        "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select. [http://search.fed.wiki.org:3030/ site]"
+        "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select. [http://query.search.federatedwiki.org/ site]"
       },
       "date": 1512277807495
     }

--- a/demo/wiki/pages/search-help
+++ b/demo/wiki/pages/search-help
@@ -1,0 +1,431 @@
+{
+  "title": "Search Help",
+  "story": [
+    {
+      "type": "paragraph",
+      "id": "055352e0caf16e24",
+      "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select. [http://search.fed.wiki.org:3030/ site]"
+    },
+    {
+      "type": "pagefold",
+      "id": "742c8c14e6d4d985",
+      "text": "choices"
+    },
+    {
+      "type": "paragraph",
+      "id": "7af72b0cdcb1c394",
+      "text": "We search various properties of pages for exact matches of search terms. Select what you would like to find."
+    },
+    {
+      "type": "html",
+      "id": "8e6df6b2da1633c4",
+      "text": "<td><input type=\"radio\" checked>words</input>\n― whole words found in item text. <br>\n\n<td><input type=\"radio\">links</input>\n― whole words found in link slugs.<br>\n\n<td><input type=\"radio\">sites</input>\n― sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n― item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n― plugin types used in stories."
+    },
+    {
+      "type": "paragraph",
+      "id": "d4652dad49a7a8f7",
+      "text": "We select based on matches of any or all these terms."
+    },
+    {
+      "type": "html",
+      "id": "1e14f79ab65c3d57",
+      "text": "<td><input type=\"radio\" checked>all</input>\n― match when all terms are present.<br>\n\n<td><input type=\"radio\">any</input>\n― match when any one term is present."
+    },
+    {
+      "type": "paragraph",
+      "id": "84380411e6889f51",
+      "text": "We report either the sites or the pages within sites where the terms are found."
+    },
+    {
+      "type": "html",
+      "id": "051452b060a3721d",
+      "text": "<td><input type=\"radio\" checked>sites</input>\n― sites were any combination of pages match.<br>\n\n<td><input type=\"radio\">pages</input>\n― pages that match by themselves.",
+      "alias": "1e14f79ab65c3d57"
+    },
+    {
+      "type": "pagefold",
+      "id": "02b79ce31feddc1b",
+      "text": "."
+    },
+    {
+      "type": "paragraph",
+      "id": "94c13ed91cf0c3c2",
+      "text": "Search terms and choices appear in the browser's location bar as a url that can be saved and rerun at any time. See [[Federation Search]] for other options."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "item": {
+        "title": "Search Help",
+        "story": []
+      },
+      "date": 1439356848173
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "055352e0caf16e24"
+      },
+      "id": "055352e0caf16e24",
+      "type": "add",
+      "date": 1439356850344
+    },
+    {
+      "type": "edit",
+      "id": "055352e0caf16e24",
+      "item": {
+        "type": "paragraph",
+        "id": "055352e0caf16e24",
+        "text": "The search web application will what it has found in the visible federation based on search terms and options selected with radio buttons."
+      },
+      "date": 1439356981715
+    },
+    {
+      "type": "edit",
+      "id": "055352e0caf16e24",
+      "item": {
+        "type": "paragraph",
+        "id": "055352e0caf16e24",
+        "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select."
+      },
+      "date": 1439357110332
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "pagefold",
+        "id": "742c8c14e6d4d985",
+        "text": "instructions"
+      },
+      "after": "055352e0caf16e24",
+      "id": "742c8c14e6d4d985",
+      "date": 1439357132728
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "7af72b0cdcb1c394",
+        "text": "We search various properties of pages for exact matches of search terms. Select what you would like to find."
+      },
+      "after": "742c8c14e6d4d985",
+      "id": "7af72b0cdcb1c394",
+      "date": 1439357138397
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "find:\n<td><input type=\"radio\" checked>words</input>\n<td><input type=\"radio\">links</input>\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "after": "7af72b0cdcb1c394",
+      "id": "8e6df6b2da1633c4",
+      "date": 1439357142896
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "d4652dad49a7a8f7",
+        "text": "We select based on matches of any or all these terms."
+      },
+      "after": "8e6df6b2da1633c4",
+      "id": "d4652dad49a7a8f7",
+      "date": 1439357146961
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "match:\n<td><input type=\"radio\" checked>all</input>\n<td><input type=\"radio\">any</input>"
+      },
+      "after": "d4652dad49a7a8f7",
+      "id": "1e14f79ab65c3d57",
+      "date": 1439357150994
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "84380411e6889f51",
+        "text": "We report either the sites or the pages within sites where the terms are found."
+      },
+      "after": "1e14f79ab65c3d57",
+      "id": "84380411e6889f51",
+      "date": 1439357155224
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "html",
+        "id": "051452b060a3721d",
+        "text": "within:\n<td><input type=\"radio\" checked>sites</input>\n<td><input type=\"radio\">pages</input>",
+        "alias": "1e14f79ab65c3d57"
+      },
+      "after": "84380411e6889f51",
+      "id": "051452b060a3721d",
+      "date": 1439357159596
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "pagefold",
+        "id": "02b79ce31feddc1b",
+        "text": "."
+      },
+      "after": "051452b060a3721d",
+      "id": "02b79ce31feddc1b",
+      "date": 1439357170242
+    },
+    {
+      "type": "edit",
+      "id": "742c8c14e6d4d985",
+      "item": {
+        "type": "pagefold",
+        "id": "742c8c14e6d4d985",
+        "text": "choices"
+      },
+      "date": 1439357187303
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n\nLook for whole words found in the text of items on pages.\n\n<td><input type=\"radio\">links</input>\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357292133
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n<p>Look for whole words found in the text of items on pages.\n\n<td><input type=\"radio\">links</input>\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357311425
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n<p>Look for whole words found in the text of items on pages.\n<td><input type=\"radio\">links</input>\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357349203
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n<br>Look for whole words found in the text of items on pages.\n<td><input type=\"radio\">links</input>\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357359452
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n<br> Look for whole words found in the text of items on pages.\n\n<td><input type=\"radio\">links</input>\n<br> look for words found in internal links.\n\n\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357427035
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- Look for whole words found in the text of items on pages.\n\n<td><input type=\"radio\">links</input>\n-- look for words found in internal links.\n\n\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357453118
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- Look for whole words found in the text of items on pages. <br>\n\n<td><input type=\"radio\">links</input>\n-- look for words found in internal links.\n\n\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357464696
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- Look for whole words found in text. <br>\n\n<td><input type=\"radio\">links</input>\n-- look for whole words found in internal links.\n\n\n<td><input type=\"radio\">sites</input>\n<td><input type=\"radio\">items</input>\n<td><input type=\"radio\">plugins</input>"
+      },
+      "date": 1439357496296
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- Look for whole words found in text. <br>\n\n<td><input type=\"radio\">links</input>\n-- Look for whole words found in internal links.<br>\n\n<td><input type=\"radio\">sites</input>\n-- Look for sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n-- Look for item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n-- Look for plugin types used in stories."
+      },
+      "date": 1439357671123
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- whole words found in text. <br>\n\n<td><input type=\"radio\">links</input>\n-- whole words found in internal links.<br>\n\n<td><input type=\"radio\">sites</input>\n-- sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n-- item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n-- plugin types used in stories."
+      },
+      "date": 1439357705996
+    },
+    {
+      "type": "edit",
+      "id": "1e14f79ab65c3d57",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "<td><input type=\"radio\" checked>all</input>\n-- match when all terms are present.<br>\n\n<td><input type=\"radio\">any</input>\n-- match when any one term is present."
+      },
+      "date": 1439357836638
+    },
+    {
+      "type": "edit",
+      "id": "051452b060a3721d",
+      "item": {
+        "type": "html",
+        "id": "051452b060a3721d",
+        "text": "<td><input type=\"radio\" checked>sites</input>\n-- sites were any combination of pages match.<br>\n\n<td><input type=\"radio\">pages</input>\n-- pages that match by themselves.",
+        "alias": "1e14f79ab65c3d57"
+      },
+      "date": 1439358062665
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- whole words found in text. <br>\n\n<td><input type=\"radio\">links</input>\n-- whole words found in links as slugs.<br>\n\n<td><input type=\"radio\">sites</input>\n-- sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n-- item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n-- plugin types used in stories."
+      },
+      "date": 1439358178581
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- whole words found in item text. <br>\n\n<td><input type=\"radio\">links</input>\n-- whole words found in link slugs.<br>\n\n<td><input type=\"radio\">sites</input>\n-- sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n-- item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n-- plugin types used in stories."
+      },
+      "date": 1439358203665
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- whole words found in item text. <br>\n\n<td><input type=\"radio\">links</input>\n-- whole words found in link slugs.<br>\n\n<td><input type=\"radio\">sites</input>\n-- sites found mentioned in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n-- item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n-- plugin types used in stories."
+      },
+      "date": 1439358232831
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n-- whole words found in item text. <br>\n\n<td><input type=\"radio\">links</input>\n-- whole words found in link slugs.<br>\n\n<td><input type=\"radio\">sites</input>\n-- sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n-- item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n-- plugin types used in stories."
+      },
+      "date": 1439358242309
+    },
+    {
+      "type": "edit",
+      "id": "8e6df6b2da1633c4",
+      "item": {
+        "type": "html",
+        "id": "8e6df6b2da1633c4",
+        "text": "<td><input type=\"radio\" checked>words</input>\n― whole words found in item text. <br>\n\n<td><input type=\"radio\">links</input>\n― whole words found in link slugs.<br>\n\n<td><input type=\"radio\">sites</input>\n― sites found in items or actions.<br>\n\n<td><input type=\"radio\">items</input>\n― item ids found in stories.<br>\n\n<td><input type=\"radio\">plugins</input>\n― plugin types used in stories."
+      },
+      "date": 1439358359542
+    },
+    {
+      "type": "edit",
+      "id": "1e14f79ab65c3d57",
+      "item": {
+        "type": "html",
+        "id": "1e14f79ab65c3d57",
+        "text": "<td><input type=\"radio\" checked>all</input>\n― match when all terms are present.<br>\n\n<td><input type=\"radio\">any</input>\n― match when any one term is present."
+      },
+      "date": 1439358369487
+    },
+    {
+      "type": "edit",
+      "id": "051452b060a3721d",
+      "item": {
+        "type": "html",
+        "id": "051452b060a3721d",
+        "text": "<td><input type=\"radio\" checked>sites</input>\n― sites were any combination of pages match.<br>\n\n<td><input type=\"radio\">pages</input>\n― pages that match by themselves.",
+        "alias": "1e14f79ab65c3d57"
+      },
+      "date": 1439358379814
+    },
+    {
+      "item": {
+        "type": "factory",
+        "id": "94c13ed91cf0c3c2"
+      },
+      "id": "94c13ed91cf0c3c2",
+      "type": "add",
+      "after": "02b79ce31feddc1b",
+      "date": 1439358408830
+    },
+    {
+      "type": "edit",
+      "id": "94c13ed91cf0c3c2",
+      "item": {
+        "type": "paragraph",
+        "id": "94c13ed91cf0c3c2",
+        "text": "Search terms and choices appear in the browser's location bar as a url that can be saved and rerun at any time."
+      },
+      "date": 1439358598344
+    },
+    {
+      "type": "edit",
+      "id": "94c13ed91cf0c3c2",
+      "item": {
+        "type": "paragraph",
+        "id": "94c13ed91cf0c3c2",
+        "text": "Search terms and choices appear in the browser's location bar as a url that can be saved and rerun at any time. See [[Federation Search]] for other options."
+      },
+      "date": 1439358659455
+    },
+    {
+      "type": "fork",
+      "site": "search.fed.wiki.org",
+      "date": 1512277782257
+    },
+    {
+      "type": "edit",
+      "id": "055352e0caf16e24",
+      "item": {
+        "type": "paragraph",
+        "id": "055352e0caf16e24",
+        "text": "The search web application will report what it has found scraping the visible federation based on search terms you provide and options you select. [http://search.fed.wiki.org:3030/ site]"
+      },
+      "date": 1512277807495
+    }
+  ]
+}

--- a/demo/wiki/pages/welcome-visitors
+++ b/demo/wiki/pages/welcome-visitors
@@ -1,0 +1,360 @@
+{
+  "title": "Welcome Visitors",
+  "story": [
+    {
+      "text": "Welcome to the [[Smallest Federated Wiki]]. From this page you can find who we are and what we do. New sites provide this information and then claim the site as their own. You will need your own site to participate.",
+      "id": "7b56f22a4b9ee974",
+      "type": "paragraph"
+    },
+    {
+      "type": "paragraph",
+      "id": "821827c99b90cfd1",
+      "text": "Pages about us."
+    },
+    {
+      "type": "paragraph",
+      "id": "63ad2e58eecdd9e5",
+      "prompt": "Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/ALT-S to save.",
+      "text": "[[Ward Cunningham]]"
+    },
+    {
+      "type": "paragraph",
+      "id": "2bbd646ff3f44b51",
+      "text": "Pages where we do and share."
+    },
+    {
+      "type": "paragraph",
+      "id": "05e2fa92643677ca",
+      "prompt": "Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/ALT-S to save.",
+      "text": "[[Federation Search]]"
+    },
+    {
+      "type": "paragraph",
+      "id": "ee416d431ebf4fb4",
+      "text": "You can edit your copy of these pages. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas. Follow [[Recent Changes]] here and nearby."
+    }
+  ],
+  "journal": [
+    {
+      "type": "create",
+      "id": "7b56f22a30118509",
+      "date": 1309114800000,
+      "item": {
+        "title": "Welcome Visitors"
+      }
+    },
+    {
+      "id": "7b56f22a4b9ee974",
+      "type": "edit",
+      "date": 1309114800000,
+      "item": {
+        "text": "Welcome to the [[Smallest Federated Wiki]]. This page was first drafted Sunday, June 26th, 2011, at [[Indie Web Camp]]. You are welcome to copy this page to any server you own and revise its welcoming message as you see fit. You can assume this has happened many times already.",
+        "id": "7b56f22a4b9ee974",
+        "type": "paragraph"
+      }
+    },
+    {
+      "type": "edit",
+      "id": "7b56f22a4b9ee974",
+      "item": {
+        "text": "Welcome to the [[Smallest Federated Wiki]]. You may be seeing this page because you have just entered a wiki of your own. If so, you have three things to do before you go on.",
+        "id": "7b56f22a4b9ee974",
+        "type": "paragraph"
+      },
+      "date": 1344306124590
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "821827c99b90cfd1",
+        "text": "<b>One:</b> Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/ALT-S to save."
+      },
+      "after": "7b56f22a4b9ee974",
+      "id": "821827c99b90cfd1",
+      "date": 1344306133455
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "factory",
+        "id": "63ad2e58eecdd9e5"
+      },
+      "after": "821827c99b90cfd1",
+      "id": "63ad2e58eecdd9e5",
+      "date": 1344306138935
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "2bbd646ff3f44b51",
+        "text": "<b>Two:</b> Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/ALT-S to save."
+      },
+      "after": "63ad2e58eecdd9e5",
+      "id": "2bbd646ff3f44b51",
+      "date": 1344306143742
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "factory",
+        "id": "05e2fa92643677ca"
+      },
+      "after": "2bbd646ff3f44b51",
+      "id": "05e2fa92643677ca",
+      "date": 1344306148580
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "0cbb4ef5f5d7e472",
+        "text": "<b>Three:</b> Look for the <i>claim</i> button below this page. If you have your own OpenID you can use it to claim these pages so that only you can edit them. If you have a Google account you can use that too. Press the (G) button. Press the (Y) button to use your Yahoo account. You get the idea."
+      },
+      "after": "05e2fa92643677ca",
+      "id": "0cbb4ef5f5d7e472",
+      "date": 1344306151782
+    },
+    {
+      "type": "add",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "Start writing. Click either link. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas. Track changes with [[Recent Changes]] and [[Local Editing]]."
+      },
+      "after": "0cbb4ef5f5d7e472",
+      "id": "ee416d431ebf4fb4",
+      "date": 1344306168918
+    },
+    {
+      "type": "edit",
+      "id": "821827c99b90cfd1",
+      "item": {
+        "type": "paragraph",
+        "id": "821827c99b90cfd1",
+        "text": "<b>One:</b> A page about myself."
+      },
+      "date": 1361751371185
+    },
+    {
+      "type": "edit",
+      "id": "2bbd646ff3f44b51",
+      "item": {
+        "type": "paragraph",
+        "id": "2bbd646ff3f44b51",
+        "text": "<b>Two:</b> Pages about what we do here."
+      },
+      "date": 1361751496155
+    },
+    {
+      "type": "edit",
+      "id": "821827c99b90cfd1",
+      "item": {
+        "type": "paragraph",
+        "id": "821827c99b90cfd1",
+        "text": "<b>One:</b> Pages about us."
+      },
+      "date": 1361751512280
+    },
+    {
+      "type": "edit",
+      "id": "7b56f22a4b9ee974",
+      "item": {
+        "text": "Welcome to the [[Smallest Federated Wiki]]. From this page you can find who we are and what we do.",
+        "id": "7b56f22a4b9ee974",
+        "type": "paragraph"
+      },
+      "date": 1361751649467
+    },
+    {
+      "type": "edit",
+      "id": "7b56f22a4b9ee974",
+      "item": {
+        "text": "Welcome to the [[Smallest Federated Wiki]]. From this introductory page you can find who we are and what we do.",
+        "id": "7b56f22a4b9ee974",
+        "type": "paragraph"
+      },
+      "date": 1361751711554
+    },
+    {
+      "type": "edit",
+      "id": "2bbd646ff3f44b51",
+      "item": {
+        "type": "paragraph",
+        "id": "2bbd646ff3f44b51",
+        "text": "<b>Two:</b> Pages where we do and share."
+      },
+      "date": 1361751811972
+    },
+    {
+      "type": "edit",
+      "id": "7b56f22a4b9ee974",
+      "item": {
+        "text": "Welcome to the [[Smallest Federated Wiki]]. From this page you can find who we are and what we do. New sites provide this information and then claim the site as their own. You will need your own site to participate.",
+        "id": "7b56f22a4b9ee974",
+        "type": "paragraph"
+      },
+      "date": 1361751965824
+    },
+    {
+      "type": "edit",
+      "id": "821827c99b90cfd1",
+      "item": {
+        "type": "paragraph",
+        "id": "821827c99b90cfd1",
+        "text": "Pages about us."
+      },
+      "date": 1361752195146
+    },
+    {
+      "type": "edit",
+      "id": "2bbd646ff3f44b51",
+      "item": {
+        "type": "paragraph",
+        "id": "2bbd646ff3f44b51",
+        "text": "Pages where we do and share."
+      },
+      "date": 1361752202873
+    },
+    {
+      "type": "edit",
+      "id": "0cbb4ef5f5d7e472",
+      "item": {
+        "type": "paragraph",
+        "id": "0cbb4ef5f5d7e472",
+        "text": "Look for the <i>claim</i> button below this page. If you have your own OpenID you can use it to claim these pages so that only you can edit them. If you have a Google account you can use that too. Press the (G) button. Press the (Y) button to use your Yahoo account. You get the idea."
+      },
+      "date": 1361752223856
+    },
+    {
+      "type": "edit",
+      "id": "ee416d431ebf4fb4",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "Click either link. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas. Track changes with [[Recent Changes]] and [[Local Editing]]."
+      },
+      "date": 1361752251367
+    },
+    {
+      "type": "edit",
+      "id": "ee416d431ebf4fb4",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "You can your copy of these pages. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas. Discover [[Recent Changes]] here and nearby."
+      },
+      "date": 1361752421212
+    },
+    {
+      "type": "edit",
+      "id": "ee416d431ebf4fb4",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "You can your copy of these pages. Press [+] to add more writing spaces."
+      },
+      "date": 1361752436556
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "78a8278db93c6ed2",
+        "text": "Read [[How to Wiki]] for more ideas. Discover [[Recent Changes]] here and nearby."
+      },
+      "id": "78a8278db93c6ed2",
+      "type": "add",
+      "after": "ee416d431ebf4fb4",
+      "date": 1361752437061
+    },
+    {
+      "type": "edit",
+      "id": "78a8278db93c6ed2",
+      "item": {
+        "type": "paragraph",
+        "id": "78a8278db93c6ed2",
+        "text": "Read [[How to Wiki]] for more ideas."
+      },
+      "date": 1361752441155
+    },
+    {
+      "item": {
+        "type": "paragraph",
+        "id": "67a126ec849b55ed",
+        "text": "Discover [[Recent Changes]] here and nearby."
+      },
+      "id": "67a126ec849b55ed",
+      "type": "add",
+      "after": "78a8278db93c6ed2",
+      "date": 1361752441668
+    },
+    {
+      "type": "remove",
+      "id": "78a8278db93c6ed2",
+      "date": 1361752452012
+    },
+    {
+      "type": "edit",
+      "id": "ee416d431ebf4fb4",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "You can your copy of these pages. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas."
+      },
+      "date": 1361752459193
+    },
+    {
+      "type": "remove",
+      "id": "67a126ec849b55ed",
+      "date": 1361752461793
+    },
+    {
+      "type": "edit",
+      "id": "ee416d431ebf4fb4",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "You can your copy of these pages. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas. Follow [[Recent Changes]] here and nearby."
+      },
+      "date": 1361752483992
+    },
+    {
+      "type": "edit",
+      "id": "ee416d431ebf4fb4",
+      "item": {
+        "type": "paragraph",
+        "id": "ee416d431ebf4fb4",
+        "text": "You can edit your copy of these pages. Press [+] to add more writing spaces. Read [[How to Wiki]] for more ideas. Follow [[Recent Changes]] here and nearby."
+      },
+      "date": 1361752498310
+    },
+    {
+      "type": "edit",
+      "id": "63ad2e58eecdd9e5",
+      "item": {
+        "type": "paragraph",
+        "id": "63ad2e58eecdd9e5",
+        "prompt": "Create a page about yourself. Start by making a link to that page right here. Double-click the gray box below. That opens an editor. Type your name enclosed in double square brackets. Then press Command/ALT-S to save.",
+        "text": "[[Ward Cunningham]]"
+      },
+      "date": 1437341175266
+    },
+    {
+      "type": "edit",
+      "id": "05e2fa92643677ca",
+      "item": {
+        "type": "paragraph",
+        "id": "05e2fa92643677ca",
+        "prompt": "Create a page about things you do on this wiki. Double-click the gray box below. Type a descriptive name of something you will be writing about. Enclose it in square brackets. Then press Command/ALT-S to save.",
+        "text": "[[Federation Search]]"
+      },
+      "date": 1437341208638
+    },
+    {
+      "type": "remove",
+      "id": "0cbb4ef5f5d7e472",
+      "date": 1437341212977
+    }
+  ]
+}


### PR DESCRIPTION
This documents the setup of the endpoints <http://query.search.federatedwiki.org> / <https://query.search.federatedwiki.org> and scheduled process to update the index.

It is a reaction to the recent waning of broad federation search support across clients.

- https://github.com/fedwiki/wiki-client/pull/340.